### PR TITLE
count grenades in buy menu to hide items when in limit

### DIFF
--- a/cli/server.php
+++ b/cli/server.php
@@ -19,7 +19,7 @@ $bindAddress = "udp://0.0.0.0:$port";
 $settings = new ServerSetting($playersMax); // must be first for correctly setting the global tickRate (Util::$TICK_RATE)
 
 $logger = new ConsoleLogger();
-$logger->info("Preparing game for launch...");
+$logger->info("Preparing game for launch, please wait...");
 
 $game = ($debug ? GameFactory::createDebug() : GameFactory::createDefaultCompetitive());
 $game->loadMap(new Maps\DefaultMap());

--- a/www/assets/js/hud/BuyMenu.js
+++ b/www/assets/js/hud/BuyMenu.js
@@ -35,6 +35,7 @@ export class BuyMenu {
         } else if (playerData.armorType === Enum.ArmorType.BODY_AND_HEAD) {
             kevlarHeadPrice = 650
         }
+        const grenadeCount = Enum.GrenadeSlots.reduce((sum, slot) => sum += playerData.slots[slot] ? playerData.slots[slot]['pcs'] || 1 : 0, 0)
 
         this.#element.innerHTML = `
             <p class="title">${teamName} Buy Store. Your money balance $ <strong>${money}</strong></p>
@@ -51,8 +52,11 @@ export class BuyMenu {
             : ``
         }
             <h3>Grenades</h3>
-            <div class="menu-grenades">
-        <p${money < 200 ? ' class="disabled"' : ''}><a data-buy-menu-item-id="${Enum.BuyMenuItem.GRENADE_FLASH}" class="hud-action action-buy">Flash for ${this.#formatPrice(200)}</a></p>
+            <div class="menu-grenades${grenadeCount >= 4 ? ' hidden' : ''}">
+        ${playerData.slots[Enum.InventorySlot.SLOT_GRENADE_FLASH] === undefined || playerData.slots[Enum.InventorySlot.SLOT_GRENADE_FLASH]['pcs'] < 2
+            ? `<p${money < 200 ? ' class="disabled"' : ''}><a data-buy-menu-item-id="${Enum.BuyMenuItem.GRENADE_FLASH}" class="hud-action action-buy">Flash for ${this.#formatPrice(200)}</a></p>`
+            : ``
+        }
         ${playerData.slots[Enum.InventorySlot.SLOT_GRENADE_SMOKE] === undefined
             ? `<p${money < 300 ? ' class="disabled"' : ''}><a data-buy-menu-item-id="${Enum.BuyMenuItem.GRENADE_SMOKE}" class="hud-action action-buy">Smoke for ${this.#formatPrice(300)}</a></p>`
             : ``


### PR DESCRIPTION
just a little ux improvement, add missing flash count and whole max 4 grenade count per inventory